### PR TITLE
Binary atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ The subprojects are as follows:
   and other type class instances for ADTs.
 - [Cats](https://github.com/typelevel/cats) provides general
   functional programming tools which complement the Scala standard library.
+- [scodec-bits](https://github.com/scodec/scodec-bits) provides an
+  immutable `ByteVector` datatype.
+
+Currently there are interop modules for the following projects:
+
 - [circe] provides the JSON framework for which `seals` derives encoders and decoders.
 - [scodec] provides a binary encoding/serialization framework for which `seals` derives codecs.
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@
 lazy val core = project
   .settings(name := "seals-core")
   .settings(commonSettings)
+  .settings(coreSettings)
   .settings(tutSettings)
   .settings(macroParadiseSettings)
 
@@ -106,6 +107,10 @@ lazy val commonSettings = Seq[Setting[_]](
   licenses := Seq("Apache 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 ) ++ typelevelDefaultSettings
 
+lazy val coreSettings = Seq[Setting[_]](
+  libraryDependencies += dependencies.scodecBits
+)
+
 lazy val lawsSettings = Seq[Setting[_]](
   libraryDependencies ++= dependencies.laws
 )
@@ -159,14 +164,17 @@ lazy val dependencies = new {
     "io.circe" %% "circe-parser" % circeVersion
   )
 
+  val scodecBits = "org.scodec" %% "scodec-bits" % "1.1.2"
+  val scodecCats = "org.scodec" %% "scodec-cats" % "0.2.0"
   val scodec = Seq(
-    "org.scodec" %% "scodec-bits" % "1.1.2",
+    scodecBits,
     "org.scodec" %% "scodec-core" % "1.10.3",
     "org.scodec" %% "scodec-stream" % "1.0.1",
-    "org.scodec" %% "scodec-cats" % "0.2.0"
+    scodecCats
   )
 
   val laws = Seq(
+    scodecCats,
     "org.typelevel" %% "cats-laws" % catsVersion,
     "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.4"
   )

--- a/circe/src/main/scala/io/sigs/seals/circe/Codec.scala
+++ b/circe/src/main/scala/io/sigs/seals/circe/Codec.scala
@@ -31,7 +31,7 @@ trait Codecs {
   implicit def encoderFromReified[A](implicit A: Reified[A]): Encoder[A] = new Encoder[A] {
     override def apply(a: A): Json = {
       val obj = A.fold(a)(Reified.Folder.instance[Json, JsonObject](
-        atom = a => Json.fromString(a),
+        atom = a => Json.fromString(a.stringRepr),
         hNil = () => JsonObject.empty,
         hCons = (l, h, t) => (l.name, h) +: t,
         prod = Json.fromJsonObject,
@@ -45,7 +45,7 @@ trait Codecs {
   implicit def decoderFromReified[A](implicit A: Reified[A]): Decoder[A] = new Decoder[A] {
     override def apply(c: HCursor): Decoder.Result[A] = {
       val x = A.unfold(Reified.Unfolder.instance[HCursor, DecodingFailure, (Boolean, HCursor)](
-        atom = { cur => cur.as[String](Decoder.decodeString).map(s => (s, cur)) },
+        atom = { cur => cur.as[String](Decoder.decodeString).map(s => Reified.StringResult(s, cur)) },
         atomErr = { cur =>
           DecodingFailure(s"cannot decode atom", cur.history)
         },

--- a/circe/src/main/scala/io/sigs/seals/circe/Codec.scala
+++ b/circe/src/main/scala/io/sigs/seals/circe/Codec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,8 +46,8 @@ trait Codecs {
     override def apply(c: HCursor): Decoder.Result[A] = {
       val x = A.unfold(Reified.Unfolder.instance[HCursor, DecodingFailure, (Boolean, HCursor)](
         atom = { cur => cur.as[String](Decoder.decodeString).map(s => Reified.StringResult(s, cur)) },
-        atomErr = { cur =>
-          DecodingFailure(s"cannot decode atom", cur.history)
+        atomErr = { (cur, err) =>
+          DecodingFailure(s"error while decoding atom: '${err.msg}'", cur.history)
         },
         hNil = { cur => cur.as[JsonObject](Decoder.decodeJsonObject).map(_ => cur) },
         hCons = { (cur, sym) =>

--- a/circe/src/test/scala/io/sigs/seals/circe/ModelCodecSpec.scala
+++ b/circe/src/test/scala/io/sigs/seals/circe/ModelCodecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -413,7 +413,7 @@ class ModelCodecSpec extends BaseJsonSpec {
               "optional" -> jfalse,
               "head" -> Json.obj(
                 "Ref" -> Json.obj(
-                  "id" -> Json.fromString("abc") // not an Int.toString
+                  "id" -> Json.fromString("abc") // NumberFormatException
                 )
               ),
               "tail" -> Json.obj(
@@ -422,7 +422,7 @@ class ModelCodecSpec extends BaseJsonSpec {
             )
           )
 
-          bad.as[Model] should failWith(".*cannot decode atom.*")
+          bad.as[Model] should failWith(".*error while decoding atom.*NumberFormatException.*")
         }
 
         "points to nonexistent ID" in {

--- a/core/src/main/scala/io/sigs/seals/core/Atomic.scala
+++ b/core/src/main/scala/io/sigs/seals/core/Atomic.scala
@@ -18,17 +18,25 @@ package io.sigs.seals
 package core
 
 import java.util.UUID
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.util.Try
 
 import cats.Eq
 import cats.implicits._
 
+import scodec.bits._
+
 trait Atomic[A] extends Serializable { this: Singleton =>
 
   def stringRepr(a: A): String
 
   def fromString(s: String): Either[String, A]
+
+  def binaryRepr(a: A): ByteVector
+
+  def fromBinary(b: ByteVector): Either[String, (A, ByteVector)]
 
   def description: String
 
@@ -48,6 +56,47 @@ trait Atomic[A] extends Serializable { this: Singleton =>
 
 object Atomic {
 
+  trait FallbackBinary[A] { this: Atomic[A] with Singleton =>
+
+    final override def binaryRepr(a: A): ByteVector = {
+      val arr = stringRepr(a).getBytes(UTF_8)
+      encodeLength(arr.length) ++ ByteVector.view(arr)
+    }
+
+    final override def fromBinary(b: ByteVector): Either[String, (A, ByteVector)] = {
+      for {
+        lenAndRest <- decodeLength(b)
+        (n, rest) = lenAndRest
+        bvs <- trySplit(rest, n.toLong)
+        (d, r) = bvs
+        s <- d.decodeUtf8.leftMap(ex => s"${ex.getClass.getSimpleName}: ${ex.getMessage}")
+        a <- fromString(s)
+      } yield (a, r)
+    }
+  }
+
+  private final def trySplit(b: ByteVector, n: Long): Either[String, (ByteVector, ByteVector)] = {
+    if (n < 0) Left(s"negative length: ${n}")
+    else if (n > b.length) Left(s"insufficient length: cannot get ${n} bytes from a vector of ${b.length}")
+    else Right(b.splitAt(n))
+  }
+
+  private final def encodeLength(i: Int): ByteVector = {
+    require(i >= 0, "negative length")
+    ByteVector.fromInt(i, 4)
+  }
+
+  private final def decodeLength(b: ByteVector): Either[String, (Int, ByteVector)] = {
+    for {
+      bvs <- trySplit(b, 4)
+      (l, r) = bvs
+      n <- l.toInt(signed = true) match {
+        case n if n < 0 => Left(s"negative encoded length: $n")
+        case n => Right(n)
+      }
+    } yield (n, r)
+  }
+
   def apply[A](implicit instance: Atomic[A]): Atomic[A] =
     instance
 
@@ -63,14 +112,39 @@ object Atomic {
     fs: String => Either[String, A]
   ) extends Atomic[A] { this: Singleton =>
 
-    override val uuid: UUID =
+    final override val uuid: UUID =
       UUID.fromString(idStr)
 
-    override def fromString(s: String): Either[String, A] =
+    final override def fromString(s: String): Either[String, A] =
       fs(s)
 
-    override def stringRepr(a: A): String =
+    final override def stringRepr(a: A): String =
       sr(a)
+  }
+
+  sealed abstract class ConstLenAtomic[A](
+    desc: String,
+    idStr: String,
+    sr: A => String,
+    fs: String => Either[String, A],
+    len: Int,
+    br: (ByteBuffer, A) => Unit,
+    fb: ByteBuffer => A
+  ) extends SimpleAtomic[A](desc, idStr, sr, fs) { this: Singleton =>
+
+    final override def binaryRepr(a: A): ByteVector = {
+      val buf = ByteBuffer.allocate(len)
+      br(buf, a)
+      buf.rewind()
+      ByteVector.view(buf)
+    }
+
+    final override def fromBinary(b: ByteVector): Either[String, (A, ByteVector)] = {
+      for {
+        bvs <- trySplit(b, len.toLong)
+        (d, r) = bvs
+      } yield (fb(d.toByteBuffer), r)
+    }
   }
 
   private[this] def fromTry[A](t: Try[A]): Either[String, A] =
@@ -81,27 +155,33 @@ object Atomic {
   implicit val builtinByte: Atomic[Byte] =
     SimpleByte
 
-  private object SimpleByte extends SimpleAtomic[Byte](
+  private object SimpleByte extends ConstLenAtomic[Byte](
     "Byte",
     "0a2d603f-b8fd-4f73-a102-3bd958d4ee22",
     _.toString,
-    s => fromTry(Try(s.toByte))
+    s => fromTry(Try(s.toByte)),
+    1,
+    _ put _,
+    _.get
   )
 
   implicit val builtinShort: Atomic[Short] =
     SimpleShort
 
-  private object SimpleShort extends SimpleAtomic[Short](
+  private object SimpleShort extends ConstLenAtomic[Short](
     "Short",
     "00d9c457-b71a-45d5-8ee8-1ecfc6af2111",
     _.toString,
-    s => fromTry(Try(s.toShort))
+    s => fromTry(Try(s.toShort)),
+    2,
+    _ putShort _,
+    _.getShort
   )
 
   implicit val builtinChar: Atomic[Char] =
     SimpleChar
 
-  private object SimpleChar extends SimpleAtomic[Char](
+  private object SimpleChar extends ConstLenAtomic[Char](
     "Char",
     "9d28d655-b16d-475d-87ac-295852deb4bc",
     String.valueOf(_),
@@ -111,51 +191,69 @@ object Atomic {
       } else {
         Left(s"not a single Char: '${s}'")
       }
-    }
+    },
+    2,
+    _ putChar _,
+    _.getChar
   )
 
   implicit val builtinInt: Atomic[Int] =
     SimpleInt
 
-  private object SimpleInt extends SimpleAtomic[Int](
+  private object SimpleInt extends ConstLenAtomic[Int](
     "Int",
     "d9bfd653-c875-4dd0-8287-b806ee6eb85b",
     _.toString,
-    s => fromTry(Try(s.toInt))
+    s => fromTry(Try(s.toInt)),
+    4,
+    _ putInt _,
+    _.getInt
   )
 
   implicit val builtinLong: Atomic[Long] =
     SimpleLong
 
-  private object SimpleLong extends SimpleAtomic[Long](
+  private object SimpleLong extends ConstLenAtomic[Long](
     "Long",
     "44e10ec2-ef7a-47b8-9851-7a5fe18a056a",
     _.toString,
-    s => fromTry(Try(s.toLong))
+    s => fromTry(Try(s.toLong)),
+    8,
+    _ putLong _,
+    _.getLong
   )
 
   implicit val builtinFloat: Atomic[Float] =
     SimpleFloat
 
-  private object SimpleFloat extends SimpleAtomic[Float](
+  private object SimpleFloat extends ConstLenAtomic[Float](
     "Float",
     "13663ca9-1652-4e4b-8c88-f7a137773b75",
     _.toString,
-    s => fromTry(Try(s.toFloat))
+    s => fromTry(Try(s.toFloat)),
+    4,
+    _ putFloat _,
+    _.getFloat
   )
 
   implicit val builtinDouble: Atomic[Double] =
     SimpleDouble
 
-  private object SimpleDouble extends SimpleAtomic[Double](
+  private object SimpleDouble extends ConstLenAtomic[Double](
     "Double",
     "18c48a4d-48fd-4755-99c8-1b545e25edda",
     _.toString,
-    s => fromTry(Try(s.toDouble))
+    s => fromTry(Try(s.toDouble)),
+    8,
+    _ putDouble _,
+    _.getDouble
   )
 
   implicit val builtinBoolean: Atomic[Boolean] =
     SimpleBoolean
+
+  private[this] final val FalseByte = hex"00"
+  private[this] final val TrueByte = hex"01"
 
   private object SimpleBoolean extends SimpleAtomic[Boolean](
     "Boolean",
@@ -166,16 +264,37 @@ object Atomic {
       else if (s === false.toString) Right(false)
       else Left(s"Not a Boolean: '${s}'")
     }
-  )
+  ) {
+
+    final override def binaryRepr(a: Boolean): ByteVector = {
+      if (a) TrueByte
+      else FalseByte
+    }
+
+    final override def fromBinary(b: ByteVector): Either[String, (Boolean, ByteVector)] = {
+      for {
+        bvs <- trySplit(b, 1)
+        (d, r) = bvs
+        a <- d match {
+          case FalseByte => Right(false)
+          case TrueByte => Right(true)
+          case _ => Left(s"invalid boolean: ${d}")
+        }
+      } yield (a, r)
+    }
+  }
 
   implicit val builtinUnit: Atomic[Unit] =
     SimpleUnit
 
-  private object SimpleUnit extends SimpleAtomic[Unit](
+  private object SimpleUnit extends ConstLenAtomic[Unit](
     "Unit",
     "d02152c8-c15b-4c74-9c3e-500af3dce57a",
     _ => "()",
-    s => if (s === "()") Right(()) else Left(s"Not '()': '${s}'")
+    s => if (s === "()") Right(()) else Left(s"Not '()': '${s}'"),
+    0,
+    (_, _) => (),
+    _ => ()
   )
 
   // Other standard types:
@@ -188,7 +307,7 @@ object Atomic {
     "8cd4c733-4392-4a8c-9014-8decf160fffe",
     identity,
     Right(_)
-  )
+  ) with FallbackBinary[String]
 
   implicit val builtinSymbol: Atomic[Symbol] =
     SimpleSymbol
@@ -198,7 +317,7 @@ object Atomic {
     "8c750487-1a6b-4c99-b01a-f1392b8177ed",
     _.name,
     s => Right(Symbol(s))
-  )
+  ) with FallbackBinary[Symbol]
 
   implicit val builtinBigInt: Atomic[BigInt] =
     SimpleBigInt
@@ -208,7 +327,26 @@ object Atomic {
     "98ed3f70-7d50-4c18-9a07-caf57cfabced",
     _.toString,
     s => fromTry(Try(BigInt(s)))
-  )
+  ) {
+
+    final override def binaryRepr(a: BigInt): ByteVector = {
+      val arr = a.underlying.toByteArray
+      encodeLength(arr.length) ++ ByteVector.view(arr)
+    }
+
+    final override def fromBinary(b: ByteVector): Either[String, (BigInt, ByteVector)] = {
+      for {
+        bvs <- decodeLength(b)
+        (n, rest) = bvs
+        bvs <- if (n > 0) {
+          trySplit(rest, n.toLong)
+        } else {
+          Left("zero length prefix for BigInt")
+        }
+        (d, r) = bvs
+      } yield (BigInt(new java.math.BigInteger(d.toArray)), r)
+    }
+  }
 
   implicit val builtinBigDecimal: Atomic[BigDecimal] =
     SimpleBigDecimal
@@ -218,16 +356,26 @@ object Atomic {
     "46317726-b42f-4147-9f99-fbbac2adce9a",
     _.toString,
     s => fromTry(Try(BigDecimal.exact(s)))
-  )
+  ) with FallbackBinary[BigDecimal]
 
   implicit val builtinUUID: Atomic[UUID] =
     SimpleUUID
 
-  private object SimpleUUID extends SimpleAtomic[UUID](
+  private object SimpleUUID extends ConstLenAtomic[UUID](
     "UUID",
     "7eba2d39-7f93-4600-8901-1e4e5ec5e7ed",
     _.toString,
-    s => fromTry(Try(UUID.fromString(s)))
+    s => fromTry(Try(UUID.fromString(s))),
+    16,
+    (buf, u) => {
+      buf.putLong(u.getMostSignificantBits)
+      buf.putLong(u.getLeastSignificantBits)
+    },
+    buf => {
+      val most = buf.getLong
+      val least = buf.getLong
+      new UUID(most, least)
+    }
   )
 
   // Registry:

--- a/core/src/main/scala/io/sigs/seals/core/Envelope.scala
+++ b/core/src/main/scala/io/sigs/seals/core/Envelope.scala
@@ -63,7 +63,6 @@ object Envelope {
       EqA.eqv(x.value, y.value)
   }
 
-  // TODO: test laws
   implicit def reifiedForEnvelope[A](implicit r: Reified[A]): Reified[Envelope[A]] = {
     Reified[EnvelopeRepr[A]].pimap[Envelope[A]] { repr =>
       if (repr.model compatible r.model) Either.right(Envelope[A](repr.value)(r))

--- a/laws/src/main/scala/io/sigs/seals/laws/ArbInstances.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/ArbInstances.scala
@@ -19,12 +19,22 @@ package laws
 
 import shapeless._
 
+import scodec.bits.ByteVector
+
 import org.scalacheck.{ Arbitrary, Gen, Cogen }
 import org.scalacheck.derive.Recursive
 
 object ArbInstances extends ArbInstances
 
 trait ArbInstances {
+
+  implicit def arbSymbol(implicit arbStr: Arbitrary[String]): Arbitrary[Symbol] = Arbitrary {
+    arbStr.arbitrary.map(Symbol.apply)
+  }
+
+  implicit def arbByteVector(implicit arbArr: Arbitrary[Array[Byte]]): Arbitrary[ByteVector] = Arbitrary {
+    arbArr.arbitrary.map(ByteVector.view)
+  }
 
   implicit def arbEnvelope[A: Reified](implicit A: Arbitrary[A]): Arbitrary[Envelope[A]] = {
     Arbitrary {

--- a/laws/src/main/scala/io/sigs/seals/laws/ArbInstances.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/ArbInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package io.sigs.seals
 package laws
 
+import java.util.UUID
+
 import shapeless._
 
 import scodec.bits.ByteVector
@@ -27,6 +29,21 @@ import org.scalacheck.derive.Recursive
 object ArbInstances extends ArbInstances
 
 trait ArbInstances {
+
+  implicit def arbUuid(implicit al: Arbitrary[Long]): Arbitrary[UUID] =
+    Arbitrary(Gen.uuid)
+
+  implicit val cogenUuid: Cogen[UUID] =
+    Cogen[String].contramap(_.toString)
+
+  implicit val arbMathContext: Arbitrary[java.math.MathContext] = {
+    Arbitrary {
+      for {
+        precision <- Gen.chooseNum(0, Int.MaxValue)
+        rounding <- Gen.oneOf(java.math.RoundingMode.values())
+      } yield new java.math.MathContext(precision, rounding)
+    }
+  }
 
   implicit def arbSymbol(implicit arbStr: Arbitrary[String]): Arbitrary[Symbol] = Arbitrary {
     arbStr.arbitrary.map(Symbol.apply)

--- a/laws/src/main/scala/io/sigs/seals/laws/AtomicLaws.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/AtomicLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,9 @@ object AtomicLaws {
     override def binaryRepr(a: Int): ByteVector =
       ByteVector.fromInt(a, 4, ByteOrdering.LittleEndian)
 
-    override def fromBinary(b: ByteVector): Either[String, (Int, ByteVector)] = {
+    override def fromBinary(b: ByteVector): Either[Atomic.Error, (Int, ByteVector)] = {
       if (b.length < 4L) {
-        Left("I need at least 4 bytes")
+        Left(Atomic.InsufficientData(4L, b.length))
       } else {
         val (d, r) = b.splitAt(4L)
         Right((d.toInt(signed = true, ByteOrdering.LittleEndian), r))
@@ -71,9 +71,9 @@ object AtomicLaws {
     override def stringRepr(a: Int): String =
       a.toString
 
-    override def fromString(s: String): Either[String, Int] = {
+    override def fromString(s: String): Either[Atomic.Error, Int] = {
       try { Right(s.toInt) }
-      catch { case ex: NumberFormatException => Left(ex.getMessage) }
+      catch { case ex: NumberFormatException => Left(Atomic.Error(ex.getMessage)) }
     }
 
     override def description: String =

--- a/laws/src/main/scala/io/sigs/seals/laws/AtomicLaws.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/AtomicLaws.scala
@@ -41,6 +41,24 @@ object AtomicLaws {
     def Equ = equ
   }
 
+  object DerivedAtomicTester
+      extends Atomic.Derived[Byte, Int] {
+
+    def from(b: Int): Either[Atomic.Error, Byte] = {
+      if ((b >= Byte.MinValue) && (b <= Byte.MaxValue)) Right(b.toByte)
+      else Left(Atomic.Error(s"out of range: ${b}"))
+    }
+
+    def to(a: Byte): Int =
+      a.toInt
+
+    def description: String =
+      "DerivedByteFromInt"
+
+    def uuid: UUID =
+      UUID.fromString("b1452721-fe47-4649-aa8b-55205b8e1098")
+  }
+
   object FallbackStringTester
       extends Atomic[Int]
       with Atomic.FallbackString[Int] {

--- a/laws/src/main/scala/io/sigs/seals/laws/CanonicalRepr.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/CanonicalRepr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ object CanonicalRepr {
       case a @ Atom(r) => Right(Reified.StringResult(r, a))
       case _ => Left("not an atom")
     },
-    atomErr = _ => "cannot decode atom",
+    atomErr = (c, err) => s"cannot decode atom: '${err.msg}'",
     hNil = {
       case hn @ HNil => Right(hn)
       case hc @ HCons(_, _, _) => Right(hc) // ignore unneeded field

--- a/laws/src/main/scala/io/sigs/seals/laws/CanonicalRepr.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/CanonicalRepr.scala
@@ -47,7 +47,7 @@ object CanonicalRepr {
     Eq.fromUniversalEquals
 
   val folder: Reified.Folder[CanonicalRepr, CanonicalRepr] = Reified.Folder.simple(
-    atom = Atom.apply,
+    atom = a => Atom(a.stringRepr),
     hNil = () => HNil,
     hCons = HCons.apply,
     sum = Sum.apply,
@@ -56,7 +56,7 @@ object CanonicalRepr {
 
   val unfolder: Reified.Unfolder[CanonicalRepr, String, Vector[CanonicalRepr]] = Reified.Unfolder.instance(
     atom = {
-      case a @ Atom(r) => Right((r, a))
+      case a @ Atom(r) => Right(Reified.StringResult(r, a))
       case _ => Left("not an atom")
     },
     atomErr = _ => "cannot decode atom",

--- a/laws/src/main/scala/io/sigs/seals/laws/ReifiedLaws.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/ReifiedLaws.scala
@@ -106,7 +106,7 @@ object ReifiedLaws {
 
   def foldToTree[A](r: Reified[A], a: A): Tree = {
     r.foldClose(a)(Reified.Folder.simple[Tree](
-      atom = Atom.apply,
+      atom = a => Atom(a.stringRepr),
       hNil = () => PNil,
       hCons = (s, h, t) => t match {
         case t: Prod => PCons(s, h, t)
@@ -134,7 +134,7 @@ trait ReifiedLaws[A] extends Laws {
       val x: Either[String, (A, Tree)] = Rei.unfold(
         Reified.Unfolder.instance[Tree, String, Vector[Tree]](
           atom = {
-            case t @ Atom(s) => Either.right((s, t))
+            case t @ Atom(s) => Either.right(Reified.StringResult(s, t))
             case _ => Either.left("not atom")
           },
           atomErr = t => s"cannot parse $t",

--- a/laws/src/main/scala/io/sigs/seals/laws/ReifiedLaws.scala
+++ b/laws/src/main/scala/io/sigs/seals/laws/ReifiedLaws.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ trait ReifiedLaws[A] extends Laws {
             case t @ Atom(s) => Either.right(Reified.StringResult(s, t))
             case _ => Either.left("not atom")
           },
-          atomErr = t => s"cannot parse $t",
+          atomErr = (t, err) => s"cannot parse ${t}: '${err.msg}'",
           hNil = {
             case PNil => Either.right(PNil)
             case x: Any => Either.left(s"not HNil: $x")

--- a/laws/src/test/scala/io/sigs/seals/laws/TestArbInstances.scala
+++ b/laws/src/test/scala/io/sigs/seals/laws/TestArbInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,10 +120,4 @@ trait TestArbInstances extends ArbInstances {
       )
     )
   }
-
-  implicit def arbUuid(implicit al: Arbitrary[Long]): Arbitrary[UUID] =
-    Arbitrary(Gen.uuid)
-
-  implicit val cogenUuid: Cogen[UUID] =
-    Cogen[String].contramap(_.toString)
 }

--- a/laws/src/test/scala/io/sigs/seals/laws/TestEqInstances.scala
+++ b/laws/src/test/scala/io/sigs/seals/laws/TestEqInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,7 @@ import cats.implicits._
 import org.scalacheck.Arbitrary
 
 /**
- * Test `cats.Eq` instances for types
- * which otherwise doesn't have a proper
- * `Eq` instance.
+ * `cats.Eq` instances which we only need for tests.
  */
 trait TestEqInstances {
 
@@ -50,4 +48,10 @@ trait TestEqInstances {
   /** Just forwarding to cats */
   implicit val symbolEq: Eq[Symbol] =
     cats.kernel.instances.symbol.catsKernelStdOrderForSymbol
+
+  implicit val mathContextEq: Eq[java.math.MathContext] =
+    Eq.fromUniversalEquals
+
+  implicit val roundingModeEq: Eq[java.math.RoundingMode] =
+    referenceEq
 }

--- a/laws/src/test/scala/io/sigs/seals/laws/TestEqInstances.scala
+++ b/laws/src/test/scala/io/sigs/seals/laws/TestEqInstances.scala
@@ -46,4 +46,8 @@ trait TestEqInstances {
 
   private def testInstances[A](arb: Arbitrary[A]): Stream[A] =
     Stream.continually(arb.arbitrary.sample).flatten.take(sampleSize)
+
+  /** Just forwarding to cats */
+  implicit val symbolEq: Eq[Symbol] =
+    cats.kernel.instances.symbol.catsKernelStdOrderForSymbol
 }

--- a/laws/src/test/scala/io/sigs/seals/laws/TestInstances.scala
+++ b/laws/src/test/scala/io/sigs/seals/laws/TestInstances.scala
@@ -31,7 +31,9 @@ object TestInstances {
     implicit val atomicMyUUID: Atomic[MyUUID] =
       AtomicMyUUID
 
-    private[this] final case object AtomicMyUUID extends Atomic[MyUUID] {
+    private[this] final case object AtomicMyUUID
+        extends Atomic[MyUUID]
+        with Atomic.FallbackBinary[MyUUID] {
 
       def description: String =
         "MyUUID"
@@ -54,7 +56,9 @@ object TestInstances {
     implicit val atomicWhatever: Atomic[Whatever.type] =
       AtomicWhatever
 
-    private[this] object AtomicWhatever extends Atomic[Whatever.type] {
+    private[this] object AtomicWhatever
+        extends Atomic[Whatever.type]
+        with Atomic.FallbackBinary[Whatever.type] {
 
       def description: String =
         "whatever"
@@ -76,7 +80,9 @@ object TestInstances {
       implicit val atomicInt: Atomic[Int] =
         BadAtomicInt
 
-      private[this] final object BadAtomicInt extends Atomic[Int] {
+      private[this] final object BadAtomicInt
+          extends Atomic[Int]
+          with Atomic.FallbackBinary[Int] {
 
         def description: String =
           "MyInt"

--- a/laws/src/test/scala/io/sigs/seals/laws/TestInstances.scala
+++ b/laws/src/test/scala/io/sigs/seals/laws/TestInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,11 +38,11 @@ object TestInstances {
       def description: String =
         "MyUUID"
 
-      def fromString(s: String): Either[String, MyUUID] = {
+      def fromString(s: String): Either[Atomic.Error, MyUUID] = {
         try {
           Either.right(MyUUID(UUID.fromString(s)))
         } catch {
-          case ex: IllegalArgumentException => Either.left(ex.getMessage)
+          case ex: IllegalArgumentException => Either.left(Atomic.Error(ex.getMessage))
         }
       }
 
@@ -63,9 +63,9 @@ object TestInstances {
       def description: String =
         "whatever"
 
-      def fromString(s: String): Either[String, Whatever.type] = {
+      def fromString(s: String): Either[Atomic.Error, Whatever.type] = {
         if (Whatever.toString.equals(s)) Either.right(Whatever)
-        else Either.left("not Whatever")
+        else Either.left(Atomic.Error("not Whatever"))
       }
 
       def stringRepr(a: Whatever.type): String =
@@ -87,8 +87,8 @@ object TestInstances {
         def description: String =
           "MyInt"
 
-        def fromString(s: String): Either[String, Int] =
-          Either.catchNonFatal(s.toInt).leftMap(_.getMessage)
+        def fromString(s: String): Either[Atomic.Error, Int] =
+          Either.catchNonFatal(s.toInt).leftMap(ex => Atomic.Error(ex.getMessage))
 
         def stringRepr(a: Int): String =
           a.toString

--- a/scodec/src/test/scala/io/sigs/seals/scodec/StreamCodecsSpec.scala
+++ b/scodec/src/test/scala/io/sigs/seals/scodec/StreamCodecsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,8 +51,7 @@ class StreamCodecsSpec extends tests.BaseSpec with GeneratorDrivenPropertyChecks
       ex.err.message should include ("incompatible models")
     }
 
-    // TODO:
-    "pipe" ignore {
+    "pipe" in {
       val bits = StreamCodec[Adt1].encodeAllValid(data1)
       forAll(genStream(bits)) { src: Stream[Pure, BitVector] =>
         src.through(StreamCodecs.pipe[Pure, Adt2]).toVector should === (data2)

--- a/scodec/src/test/scala/io/sigs/seals/scodec/StreamCodecsSpec.scala
+++ b/scodec/src/test/scala/io/sigs/seals/scodec/StreamCodecsSpec.scala
@@ -51,7 +51,8 @@ class StreamCodecsSpec extends tests.BaseSpec with GeneratorDrivenPropertyChecks
       ex.err.message should include ("incompatible models")
     }
 
-    "pipe" in {
+    // TODO:
+    "pipe" ignore {
       val bits = StreamCodec[Adt1].encodeAllValid(data1)
       forAll(genStream(bits)) { src: Stream[Pure, BitVector] =>
         src.through(StreamCodecs.pipe[Pure, Adt2]).toVector should === (data2)

--- a/tests/src/test/scala/io/sigs/seals/tests/AtomicSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/AtomicSpec.scala
@@ -105,4 +105,15 @@ class AtomicSpec extends BaseSpec with GeneratorDrivenPropertyChecks with Inside
         a.uuid should === (constUuid)
     }
   }
+
+  // FIXME: what to do with this?
+  "Non-ASCII numerals" ignore {
+    val s = "꩒" // U+AA52 CHAM DIGIT TWO
+    Atomic[Int].fromString(s) match {
+      case Left(err) =>
+        // OK
+      case r @ Right(_) =>
+        fail(s"expected failure to parse, got ${r} as a result")
+    }
+  }
 }

--- a/tests/src/test/scala/io/sigs/seals/tests/AtomicSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/AtomicSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,11 +72,11 @@ class AtomicSpec extends BaseSpec with GeneratorDrivenPropertyChecks with Inside
 
         def description: String = "CaseClass"
 
-        def fromString(s: String): Either[String, CaseClass] = {
+        def fromString(s: String): Either[Atomic.Error, CaseClass] = {
           try {
             Either.right(CaseClass(s.toLong))
           } catch {
-            case ex: IllegalArgumentException => Either.left(ex.getMessage)
+            case ex: IllegalArgumentException => Either.left(Atomic.Error(ex.getMessage))
           }
         }
 
@@ -108,12 +108,17 @@ class AtomicSpec extends BaseSpec with GeneratorDrivenPropertyChecks with Inside
 
   // FIXME: what to do with this?
   "Non-ASCII numerals" ignore {
-    val s = "꩒" // U+AA52 CHAM DIGIT TWO
-    Atomic[Int].fromString(s) match {
-      case Left(err) =>
-        // OK
-      case r @ Right(_) =>
-        fail(s"expected failure to parse, got ${r} as a result")
+    val strings = Vector(
+      "꩒", // U+AA52 CHAM DIGIT TWO
+      "꘢"  // U+A622 VAI DIGIT TWO
+    )
+    for (s <- strings) {
+      Atomic[Int].fromString(s) match {
+        case Left(err) =>
+          // OK
+        case r @ Right(_) =>
+          fail(s"expected failure to parse, got ${r} as a result")
+      }
     }
   }
 }

--- a/tests/src/test/scala/io/sigs/seals/tests/AtomicSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/AtomicSpec.scala
@@ -68,7 +68,7 @@ class AtomicSpec extends BaseSpec with GeneratorDrivenPropertyChecks with Inside
     // define an atomic:
     val constUuid = UUID.fromString("3ba1f17e-c0cd-4b17-8cca-771e90b60498")
     val r2 = {
-      object ACC extends Atomic[CaseClass] {
+      object ACC extends Atomic[CaseClass] with Atomic.FallbackBinary[CaseClass] {
 
         def description: String = "CaseClass"
 

--- a/tests/src/test/scala/io/sigs/seals/tests/BuiltinAtomSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/BuiltinAtomSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.sigs.seals
 package tests
 
 import java.util.UUID
+import java.math.{ MathContext, RoundingMode }
 
 class BuiltinAtomSpec extends BaseSpec {
 
@@ -40,6 +41,8 @@ class BuiltinAtomSpec extends BaseSpec {
       atom[Symbol],
       atom[BigInt],
       atom[BigDecimal],
+      atom[MathContext],
+      atom[RoundingMode],
       atom[UUID]
     )
     atoms.map(_.uuid).toSet should have size atoms.size.toLong

--- a/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
@@ -62,6 +62,7 @@ class LawsSpec extends BaseLawsSpec {
   checkAtomicLaws[BigDecimal]("BigDecimal")
   checkAtomicLaws[UUID]("UUID")
 
+  checkAtomicLaws[Byte]("DerivedAtomicTester")(implicitly, implicitly, AtomicLaws.DerivedAtomicTester)
   checkAtomicLaws[Int]("FallbackStringTester")(implicitly, implicitly, AtomicLaws.FallbackStringTester)
   checkAtomicLaws[Int]("FallbackBinaryTester")(implicitly, implicitly, AtomicLaws.FallbackBinaryTester)
 

--- a/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
@@ -47,6 +47,21 @@ class LawsSpec extends BaseLawsSpec {
     checkReifiedLaws[UUID, Int, Int]("UUID")
   }
 
+  checkAtomicLaws[Byte]("Byte")
+  checkAtomicLaws[Short]("Short")
+  checkAtomicLaws[Char]("Char")
+  checkAtomicLaws[Int]("Int")
+  checkAtomicLaws[Long]("Long")
+  checkAtomicLaws[Float]("Float")
+  checkAtomicLaws[Double]("Double")
+  checkAtomicLaws[Boolean]("Boolean")
+  checkAtomicLaws[Unit]("Unit")
+  checkAtomicLaws[String]("String")
+  checkAtomicLaws[Symbol]("Symbol")
+  checkAtomicLaws[BigInt]("BigInt")
+  checkAtomicLaws[BigDecimal]("BigDecimal")
+  checkAtomicLaws[UUID]("UUID")
+
   locally {
     import TestInstances.atomic._
     checkAtomicLaws[MyUUID]("MyUUID")

--- a/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Daniel Urban
+ * Copyright 2016-2017 Daniel Urban
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.sigs.seals
 package tests
 
 import java.util.UUID
+import java.math.{ MathContext, RoundingMode }
 
 import cats.kernel.laws._
 import cats.laws.discipline.InvariantMonoidalTests
@@ -60,6 +61,8 @@ class LawsSpec extends BaseLawsSpec {
   checkAtomicLaws[Symbol]("Symbol")
   checkAtomicLaws[BigInt]("BigInt")
   checkAtomicLaws[BigDecimal]("BigDecimal")
+  checkAtomicLaws[MathContext]("MathContext")
+  checkAtomicLaws[RoundingMode]("RoundingMode")
   checkAtomicLaws[UUID]("UUID")
 
   checkAtomicLaws[Byte]("DerivedAtomicTester")(implicitly, implicitly, AtomicLaws.DerivedAtomicTester)

--- a/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
+++ b/tests/src/test/scala/io/sigs/seals/tests/LawsSpec.scala
@@ -62,6 +62,9 @@ class LawsSpec extends BaseLawsSpec {
   checkAtomicLaws[BigDecimal]("BigDecimal")
   checkAtomicLaws[UUID]("UUID")
 
+  checkAtomicLaws[Int]("FallbackStringTester")(implicitly, implicitly, AtomicLaws.FallbackStringTester)
+  checkAtomicLaws[Int]("FallbackBinaryTester")(implicitly, implicitly, AtomicLaws.FallbackBinaryTester)
+
   locally {
     import TestInstances.atomic._
     checkAtomicLaws[MyUUID]("MyUUID")


### PR DESCRIPTION
Support for binary representation of atoms.

- [x] implementation
- [x] fix #35
- [x] add `scodec-bits` dependency to readme