### PR TITLE
Fix sealed package error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,15 @@ lazy val plugin = project
   .enablePlugins(ScriptedPlugin)
   .settings(commonSettings)
   .settings(pluginSettings)
+  .settings(scriptedDependencies := {
+    scriptedDependencies.value
+    // workaround for https://github.com/sbt/sbt/issues/3248
+    (checker / publishLocal).value
+    (core / publishLocal).value
+    (circe / publishLocal).value
+    (macros / publishLocal).value
+    (scodec / publishLocal).value // due to the scripted test "seals-plugin / example"
+  })
 
 lazy val circe = project
   .settings(name := s"seals-circe")

--- a/checker/src/main/scala/dev/tauri/seals/checker/Checker.scala
+++ b/checker/src/main/scala/dev/tauri/seals/checker/Checker.scala
@@ -1,5 +1,7 @@
 /*
  * Copyright 2017-2020 Daniel Urban and contributors listed in AUTHORS
+ * Copyright 2020 Nokia
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +29,6 @@ import cats.implicits._
 
 import io.circe.parser
 
-import circe.Codecs._
-
 object Checker {
 
   type ErrorMsg = String
@@ -55,20 +55,20 @@ object Checker {
     Console.println(sh"All ${nModels} checked models are compatible.") // scalastyle:ignore regex
   }
 
-  def loadModels(path: String): Map[String, Map[String, Model]] = {
+  def loadModels(path: String): ModelSet = {
     val str = Files.readAllLines(Paths.get(path), StandardCharsets.UTF_8).asScala.mkString
-    parser.decode[Map[String, Map[String, Model]]](str).fold(
+    parser.decode[ModelSet](str).fold(
       err => throw new IllegalArgumentException(sh"error while decoding '${path}': ${err}"),
       models => models
     )
   }
 
-  def compareModelSet(currModels: Map[String, Map[String, Model]], prevModels: Map[String, Map[String, Model]]): Report = {
-    assertSameKeys("packages", currModels, prevModels)
-    (for (pack <- currModels.keys) yield {
-      val curr = currModels(pack)
-      val prev = prevModels(pack)
-      pack -> comparePackage(curr, prev)
+  def compareModelSet(curr: ModelSet, prev: ModelSet): Report = {
+    assertSameKeys("packages", curr.models, prev.models)
+    (for (pack <- curr.models.keys) yield {
+      val currPak = curr.models(pack)
+      val prevPak = prev.models(pack)
+      pack -> comparePackage(currPak, prevPak)
     }).toMap
   }
 

--- a/checker/src/main/scala/dev/tauri/seals/checker/ModelSet.scala
+++ b/checker/src/main/scala/dev/tauri/seals/checker/ModelSet.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Daniel Urban and contributors listed in AUTHORS
+ * Copyright 2020 Nokia
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.tauri.seals
+package checker
+
+import io.circe.{ Encoder, Decoder }
+
+import circe.Codecs
+
+/** A newtype for fine-grained control over the JSON format */
+final case class ModelSet(models: Map[String, Map[String, Model]])
+
+final object ModelSet {
+
+  implicit val encoderInstance: Encoder[ModelSet] = {
+    // Note: we're explicitly only using `Reified` for decoding `Model`,
+    // otherwise we want the default behavior of circe.
+    implicit val mEnc: Encoder[Model] = Codecs.encoderFromReified[Model]
+    Encoder[Map[String, Map[String, Model]]].contramap(_.models)
+  }
+
+  implicit val decoderInstance: Decoder[ModelSet] = {
+    // Note: we're explicitly only using `Reified` for encoding `Model`,
+    // otherwise we want the default behavior of circe.
+    implicit val mDec: Decoder[Model] = Codecs.decoderFromReified[Model]
+    Decoder[Map[String, Map[String, Model]]].map(ModelSet(_))
+  }
+}

--- a/checker/src/test/scala/dev/tauri/seals/checker/ExtractorSpec.scala
+++ b/checker/src/test/scala/dev/tauri/seals/checker/ExtractorSpec.scala
@@ -1,5 +1,7 @@
 /*
  * Copyright 2016-2020 Daniel Urban and contributors listed in AUTHORS
+ * Copyright 2020 Nokia
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +22,7 @@ package checker
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import io.circe.{ Decoder, JsonObject }
+import io.circe.Decoder
 
 import circe.Codecs._
 
@@ -54,11 +56,7 @@ class ExtractorSpec extends AnyFlatSpec with Matchers {
   }
 
   "Extractor#extractAll" should "find all marked classes in a package" in {
-    val json = extractor.extractAll(pack)
-    val models = json.as[JsonObject]
-      .fold(err => fail(err.toString), identity)
-      .toMap
-      .mapValues(j => decoder.decodeJson(j).fold(err => fail(err.toString), identity))
+    val models: Map[String, Model] = extractor.extractAll(pack)
     val expected = Map(
       fooName -> Foo.reifiedFoo.model,
       ccName -> CC.reifiedCC.model,

--- a/core/src/main/scala/dev/tauri/seals/core/CanonicalRepr.scala
+++ b/core/src/main/scala/dev/tauri/seals/core/CanonicalRepr.scala
@@ -43,6 +43,10 @@ object CanonicalRepr {
     )
   }
 
+  def product(els: (Symbol, CanonicalRepr)*): CanonicalRepr = {
+    els.foldRight[CanonicalRepr](CanonicalRepr.HNil) { case ((lab, r), acc) => CanonicalRepr.HCons(lab, r, acc) }
+  }
+
   implicit val orderForCanonicalRepr: Order[CanonicalRepr] = {
     case (Atom(x), Atom(y)) =>
       Order[String].compare(x, y)

--- a/core/src/main/scala/dev/tauri/seals/core/Refinement.scala
+++ b/core/src/main/scala/dev/tauri/seals/core/Refinement.scala
@@ -123,8 +123,11 @@ object Refinement {
       Semantics((root / lt / repr).uuid, ReprFormat("", true, sh" < ${than}"))
     }
 
-    val unique: Semantics =
-      Semantics((root / uq).uuid, ReprFormat("unique{", true, "}"))
+    val set: Semantics =
+      Semantics((root / setId).uuid, ReprFormat("set{", true, "}"))
+
+    val map: Semantics =
+      Semantics((root / mapId).uuid, ReprFormat("map{", true, "}"))
 
     implicit val eqForSemantics: Eq[Semantics] =
       Eq.fromUniversalEquals
@@ -175,7 +178,8 @@ object Refinement {
   private[this] final val gt = uuid"ff6383db-8d2e-4507-a571-f6f0f73f1fe8"
   private[this] final val lt = uuid"95d56687-589e-4e8a-8857-0707ad3cd60b"
   private[this] final val en = uuid"5c7fe757-72c0-4114-9ed0-06e8a8d34c04"
-  private[this] final val uq = uuid"76fabf3e-5531-4f66-8d35-be6c79c2b070"
+  private[this] final val setId = uuid"76fabf3e-5531-4f66-8d35-be6c79c2b070"
+  private[this] final val mapId = uuid"b59c7b70-19df-42c6-8e91-081d0790e1b9"
 
   def enum[A](implicit A: EnumLike[A]): Refinement.Aux[A, Int] = new Refinement[A] {
     override type Repr = Int

--- a/laws/src/test/scala/dev/tauri/seals/laws/ATestTypes.scala
+++ b/laws/src/test/scala/dev/tauri/seals/laws/ATestTypes.scala
@@ -290,7 +290,7 @@ object TestTypes {
 
     final case class WithSet(i: Int, l: Set[Float]) extends Adt
     object WithSet {
-      val expModel = 'i -> atom[Int] :: 'l -> Model.Vector(atom[Float], Some(Refinement.Semantics.unique)) :: Model.HNil
+      val expModel = 'i -> atom[Int] :: 'l -> Model.Vector(atom[Float], Some(Refinement.Semantics.set)) :: Model.HNil
     }
 
     final case class WithVector(els: Vector[Adt]) extends Adt

--- a/refined/src/main/scala/dev/tauri/seals/refined/AllInstances.scala
+++ b/refined/src/main/scala/dev/tauri/seals/refined/AllInstances.scala
@@ -17,14 +17,8 @@
  */
 
 package dev.tauri.seals
+package refined
 
-import cats.Show
-
-import shapeless.Nat
-import shapeless.ops.nat.ToInt
-
-package object refined extends AllInstances {
-
-  implicit def catsShowForShapelessNat[N <: Nat](implicit ti: ToInt[N], si: Show[Int]): Show[N] =
-    Show.show(_ => si.show(ti()))
-}
+trait AllInstances
+  extends Refinements
+  with ReifiedInstances

--- a/refined/src/main/scala/dev/tauri/seals/refined/package.scala
+++ b/refined/src/main/scala/dev/tauri/seals/refined/package.scala
@@ -1,5 +1,7 @@
 /*
  * Copyright 2017-2020 Daniel Urban and contributors listed in AUTHORS
+ * Copyright 2020 Nokia
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +25,7 @@ import shapeless.ops.nat.ToInt
 
 package object refined extends AllInstances {
 
-  private[refined] implicit def catsShowForShapelessNat[N <: Nat](implicit ti: ToInt[N], si: Show[Int]): Show[N] =
+  implicit def catsShowForShapelessNat[N <: Nat](implicit ti: ToInt[N], si: Show[Int]): Show[N] =
     Show.show(_ => si.show(ti()))
 }
 

--- a/scodec/src/test/scala/dev/tauri/seals/scodec/CodecsSpec.scala
+++ b/scodec/src/test/scala/dev/tauri/seals/scodec/CodecsSpec.scala
@@ -140,6 +140,21 @@ class CodecsSpec extends tests.BaseSpec {
         Attempt.successful(DecodeResult(WithList(42, List(42.0f)), hex"ff".bits))
       )
     }
+
+    "Duplicates must be rejected" - {
+
+      "Sets" in {
+        decoderFromReified[Set[Int]].decode(
+          hex"0000 0002  ${ci(42)}  ${ci(42)}   dead".bits
+        ).toEither.swap.getOrElse(fail).message should === ("duplicate elements")
+      }
+
+      "Maps" in {
+        decoderFromReified[Map[Int, Int]].decode(
+          hex"0000 0002  A2 ${vl(4)} ${ci(42)}  A2 ${vl(4)} ${ci(0)}  A1   A2 ${vl(4)} ${ci(42)}  A2 ${vl(4)} ${ci(1)}  A1  dead".bits
+        ).toEither.swap.getOrElse(fail).message should === ("duplicate keys")
+      }
+    }
   }
 
   "Roundtrip" - {
@@ -152,6 +167,8 @@ class CodecsSpec extends tests.BaseSpec {
       Codec.decode[U](Codec.encode[U](Union[U](b = 42)).getOrElse(fail)).getOrElse(fail).value should === (Union[U](b = 42))
       Codec.decode[Adt1](Codec.encode[Adt1](Adt1.C(42)).getOrElse(fail)).getOrElse(fail).value should === (Adt1.C(42))
       Codec.decode[Vector[Int]](Codec.encode[Vector[Int]](Vector(42, 43)).getOrElse(fail)).getOrElse(fail).value should === (Vector(42, 43))
+      Codec.decode[Set[Int]](Codec.encode[Set[Int]](Set(1, 3, 4)).getOrElse(fail)).getOrElse(fail).value should === (Set(1, 3, 4))
+      Codec.decode[Map[Int, Int]](Codec.encode[Map[Int, Int]](Map(1 -> 2, 3 -> 6)).getOrElse(fail)).getOrElse(fail).value should === (Map(1 -> 2, 3 -> 6))
       Codec.decode[WithList](Codec.encode[WithList](WithList(42, List(42.0f))).getOrElse(fail)).getOrElse(fail).value should === (WithList(42, List(42.0f)))
     }
 

--- a/tests/src/test/scala/dev/tauri/seals/tests/CanonicalReprSpec.scala
+++ b/tests/src/test/scala/dev/tauri/seals/tests/CanonicalReprSpec.scala
@@ -57,4 +57,28 @@ class CanonicalReprSpec
       }
     }
   }
+
+  "product" should "create correct HCons/HNil" in {
+    import CanonicalRepr.{ HCons, HNil }
+    val act = CanonicalRepr.product(
+      'a -> CanonicalRepr.Atom("1"),
+      'b -> CanonicalRepr.Atom("2"),
+      'c -> CanonicalRepr.Atom("3")
+    )
+    val exp = HCons(
+      'a,
+      CanonicalRepr.Atom("1"),
+      HCons(
+        'b,
+        CanonicalRepr.Atom("2"),
+        HCons(
+          'c,
+          CanonicalRepr.Atom("3"),
+          HNil
+        )
+      )
+    )
+    act should === (exp)
+    CanonicalRepr.product() should === (HNil)
+  }
 }

--- a/tests/src/test/scala/dev/tauri/seals/tests/CompatSpec.scala
+++ b/tests/src/test/scala/dev/tauri/seals/tests/CompatSpec.scala
@@ -128,5 +128,9 @@ class CompatSpec extends BaseSpec {
       import TestTypes.collections.{ WithList, WithSet }
       illTyped("Compat[WithList, WithSet]", notFound)
     }
+
+    "Set and Map are different" in {
+      illTyped("Compat[Set[(Int, String)], Map[Int, String]]", notFound)
+    }
   }
 }

--- a/tests/src/test/scala/dev/tauri/seals/tests/LawsSpec.scala
+++ b/tests/src/test/scala/dev/tauri/seals/tests/LawsSpec.scala
@@ -52,6 +52,7 @@ class LawsSpec extends BaseLawsSpec {
   checkReifiedLaws[Envelope[TestTypes.adts.recursive.IntList], Int, Int]("Envelope[IntList]")
   checkReifiedLaws[List[String], Boolean, Float]("List[String]")
   checkReifiedLaws[Set[Int], String, Double]("Set[Int]")
+  checkReifiedLaws[Map[Int, Float], String, Double]("Map[Int, Float]")
   checkReifiedLaws[Option[Int], String, Float]("Option[Int]")
   checkReifiedLaws[Month, String, Float]("java.time.Month")
   checkReifiedLaws[Symbol, Float, Option[Int]]("scala.Symbol")

--- a/tests/src/test/scala/dev/tauri/seals/tests/RefinementSpec.scala
+++ b/tests/src/test/scala/dev/tauri/seals/tests/RefinementSpec.scala
@@ -99,10 +99,14 @@ class RefinementSpec extends BaseSpec {
       checkNotEqHash(tricky1, tricky2)
     }
 
-    "unique" in {
-      checkEqHash(Refinement.Semantics.unique, Refinement.Semantics.unique)
-      checkNotEqHash(Refinement.Semantics.unique, Refinement.Semantics.greater[Foo](Foo(5, "ert")))
-      Refinement.Semantics.unique.repr.repr("?") should === ("unique{?}")
+    "set/map" in {
+      checkEqHash(Refinement.Semantics.set, Refinement.Semantics.set)
+      checkEqHash(Refinement.Semantics.map, Refinement.Semantics.map)
+      checkNotEqHash(Refinement.Semantics.set, Refinement.Semantics.map)
+      checkNotEqHash(Refinement.Semantics.set, Refinement.Semantics.greater[Foo](Foo(5, "ert")))
+      checkNotEqHash(Refinement.Semantics.map, Refinement.Semantics.greater[Foo](Foo(5, "ert")))
+      Refinement.Semantics.set.repr.repr("?") should === ("set{?}")
+      Refinement.Semantics.map.repr.repr("?") should === ("map{?}")
     }
   }
 

--- a/tests/src/test/scala/dev/tauri/seals/tests/SerializableSpec.scala
+++ b/tests/src/test/scala/dev/tauri/seals/tests/SerializableSpec.scala
@@ -142,6 +142,8 @@ class SerializableSpec extends BaseSpec {
 
     "Refined instances" in {
       roundtripSer(Reified[Int].refined(Refinement.enum[DayOfWeek]))
+      roundtripSer(Reified[Set[Int]])
+      roundtripSer(Reified[Map[Int, String]])
     }
   }
 
@@ -208,6 +210,10 @@ class SerializableSpec extends BaseSpec {
 
     "ExtSet" in {
       roundtripSer(core.ExtSet[Set, String])
+    }
+
+    "ExtMap" in {
+      roundtripSer(core.ExtMap[Map, String, Boolean])
     }
   }
 


### PR DESCRIPTION
Move `AllInstances` to the `dev.tauri.seals.refined` package, to avoid `SecurityException: sealing violation` errors.

(This PR depends on #81.)